### PR TITLE
Global slack-json support.

### DIFF
--- a/Actions/PullRequestAction.cs
+++ b/Actions/PullRequestAction.cs
@@ -9,11 +9,11 @@ namespace Slack.Json.Actions
 {
     public class PullRequestAction : IRequestAction
     {
-        private readonly ISlackFileFetcher fetcher;
+        private readonly ISlackActionFetcher fetcher;
         private readonly ISlackMessaging slack;
         private readonly ILogger<PullRequestAction> logger;
 
-        public PullRequestAction(ISlackFileFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
+        public PullRequestAction(ISlackActionFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
         {
             this.fetcher = fetcher;
             this.slack = slack;

--- a/Actions/ReviewRequestAction.cs
+++ b/Actions/ReviewRequestAction.cs
@@ -9,11 +9,11 @@ namespace Slack.Json.Actions
 {
     public class ReviewRequestAction: IRequestAction
     {
-        private ISlackFileFetcher fetcher;
+        private ISlackActionFetcher fetcher;
         private ISlackMessaging slack;
         private ILogger<PullRequestAction> logger;
 
-        public ReviewRequestAction(ISlackFileFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
+        public ReviewRequestAction(ISlackActionFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
         {
             this.fetcher = fetcher;
             this.slack = slack;

--- a/Actions/ReviewStatusAction.cs
+++ b/Actions/ReviewStatusAction.cs
@@ -9,11 +9,11 @@ namespace Slack.Json.Actions
 {
     public class ReviewStatusAction : IRequestAction
     {
-        private readonly ISlackFileFetcher fetcher;
+        private readonly ISlackActionFetcher fetcher;
         private readonly ISlackMessaging slack;
         private readonly ILogger<PullRequestAction> logger;
 
-        public ReviewStatusAction(ISlackFileFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
+        public ReviewStatusAction(ISlackActionFetcher fetcher, ISlackMessaging slack, ILogger<PullRequestAction> logger)
         {
             this.fetcher = fetcher;
             this.slack = slack;

--- a/AppOptions.cs
+++ b/AppOptions.cs
@@ -1,8 +1,14 @@
+using System.Collections.Generic;
+using Slack.Json.Github;
+
 namespace Slack.Json
 {
     public class AppOptions
     {
         public string SlackIntegrationUri { get; set; }
         public string GithubPersonalAccessToken { get; set; }
+
+        // This applies to every repository, enabled even when slack.json is missing.
+        public IEnumerable<SlackActionModel> GlobalSlackJson { get; set; }
     }
 }

--- a/Github/ISlackFileFetcher.cs
+++ b/Github/ISlackFileFetcher.cs
@@ -3,7 +3,7 @@ using Optional;
 
 namespace Slack.Json.Github
 {
-    public interface ISlackFileFetcher
+    public interface ISlackActionFetcher
     {
         IEnumerable<SlackActionModel> GetJsonIfAny(string owner, string repo);
     }

--- a/Startup.cs
+++ b/Startup.cs
@@ -45,7 +45,7 @@ namespace Slack.Json
             services.AddMvc();
 
             services.AddTransient<ISlackMessaging, SlackMessaging>();
-            services.AddTransient<ISlackFileFetcher, SlackFileFetcher>();
+            services.AddTransient<ISlackActionFetcher, SlackActionFetcher>();
             services.AddTransient<PullRequestAction>();
             services.AddTransient<ReviewRequestAction>();
             services.AddTransient<ReviewStatusAction>();

--- a/Tests/DepencyMockFactories.cs
+++ b/Tests/DepencyMockFactories.cs
@@ -6,9 +6,9 @@ namespace Slack.Json.Tests
 {
     public static class DepencyMockFactories
     {
-        public static ISlackFileFetcher SlackFileFetcherMock(string type, string channel)
+        public static ISlackActionFetcher SlackFileFetcherMock(string type, string channel)
         {
-            var fetcher = Substitute.For<ISlackFileFetcher>();
+            var fetcher = Substitute.For<ISlackActionFetcher>();
 
             fetcher
                 .GetJsonIfAny(Arg.Is<string>("protacon"), Arg.Is<string>("testrepo"))

--- a/Tests/PullRequestActionTests.cs
+++ b/Tests/PullRequestActionTests.cs
@@ -16,7 +16,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenRepositoryDoesntContainSlackJson_ThenIgnoreRequest()
         {
-            var fetcher = Substitute.For<ISlackFileFetcher>();
+            var fetcher = Substitute.For<ISlackActionFetcher>();
             fetcher
                 .GetJsonIfAny(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(Enumerable.Empty<SlackActionModel>());
@@ -47,7 +47,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenSlackJsonDoesntContainPullRequestAction_ThenIgnoreSend()
         {
-            var fetcher = Substitute.For<ISlackFileFetcher>();
+            var fetcher = Substitute.For<ISlackActionFetcher>();
             fetcher
                 .GetJsonIfAny(Arg.Is<string>("protacon"), Arg.Is<string>("testrepo"))
                 .Returns(Enumerable.Empty<SlackActionModel>());

--- a/Tests/ReviewRequestActionTests.cs
+++ b/Tests/ReviewRequestActionTests.cs
@@ -15,7 +15,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenRepositoryDoesntContainSlackJson_ThenIgnoreRequest()
         {
-            var fetcher = Substitute.For<ISlackFileFetcher>();
+            var fetcher = Substitute.For<ISlackActionFetcher>();
             fetcher
                 .GetJsonIfAny(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(Enumerable.Empty<SlackActionModel>());
@@ -32,7 +32,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenValidRequestIsSent_ThenSendNotifications()
         {
-            ISlackFileFetcher fetcher = DepencyMockFactories.SlackFileFetcherMock("review_request", "#general");
+            ISlackActionFetcher fetcher = DepencyMockFactories.SlackFileFetcherMock("review_request", "#general");
 
             var slack = Substitute.For<ISlackMessaging>();
 
@@ -46,7 +46,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenSlackJsonDoesntContainReviewRequestAction_ThenIgnoreSend()
         {
-            var fetcher = Substitute.For<ISlackFileFetcher>();
+            var fetcher = Substitute.For<ISlackActionFetcher>();
             fetcher
                 .GetJsonIfAny(Arg.Is<string>("protacon"), Arg.Is<string>("testrepo"))
                 .Returns(Enumerable.Empty<SlackActionModel>());

--- a/Tests/ReviewStatusActionTests.cs
+++ b/Tests/ReviewStatusActionTests.cs
@@ -13,7 +13,7 @@ namespace Slack.Json.Tests
         [Fact]
         public void WhenChangesAreRequested_ThenSendCorrectSlackMessage()
         {
-            ISlackFileFetcher fetcher = DepencyMockFactories.SlackFileFetcherMock("review_status", "#general");
+            ISlackActionFetcher fetcher = DepencyMockFactories.SlackFileFetcherMock("review_status", "#general");
 
             var slack = Substitute.For<ISlackMessaging>();
 

--- a/Tests/Testers.cs
+++ b/Tests/Testers.cs
@@ -11,7 +11,7 @@ namespace Slack.Json.Tests
         [Fact(Skip="tester")]
         public void TesterForSlackJsonFetcher()
         {
-            var fether = new SlackFileFetcher(Options.Create(new AppOptions {
+            var fether = new SlackActionFetcher(Options.Create(new AppOptions {
                 GithubPersonalAccessToken = "revoked_this"
             }));
             var result = fether.GetJsonIfAny("protacon", "testrepo");


### PR DESCRIPTION
This allows global configuration, configurations that are applied to every repository in organization. This way certain actions like channel x will get notification if new public repository is created or when 'needs help' labels is added.