### PR TITLE
Add link to slack Incoming webhook app

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -it \
 
 ## Slack configuration
 
-1. Create new 'Incoming webhook' app and set 'Webhook URL' to appsettings.json or environment variable `SlackIntegrationUri`.
+1. Create new ['Incoming webhook' app](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) and set 'Webhook URL' to appsettings.json or environment variable `SlackIntegrationUri`.
 
 ## slack.json
 


### PR DESCRIPTION
It's really easy to misunderstand and use the plain incoming webhook. It's pretty similar but doesn't support pushing to other channels. Been there, done that.

Hook has to be done with the separated app to make it work with multiple channels.

https://slack.com/apps/A0F7XDUAZ-incoming-webhooks